### PR TITLE
Change removeObserver() visibility from private to public

### DIFF
--- a/SpringIndicator/SpringIndicator.swift
+++ b/SpringIndicator/SpringIndicator.swift
@@ -476,7 +476,7 @@ public extension SpringIndicator {
             targetView?.addObserver(self, forKeyPath: Me.ObserverOffsetKeyPath, options: .New, context: &RefresherContext)
         }
         
-        private func removeObserver() {
+        public func removeObserver() {
             targetView?.removeObserver(self, forKeyPath: Me.ObserverOffsetKeyPath, context: &RefresherContext)
         }
         


### PR DESCRIPTION
WHAT
======

`SpringIndicator.Refresher.removeObserver()`の可視性を`private`から`public`に変更。

WHY
======

`removeFormSuperView()`したとき、observerが登録され続けたままになるため、明示的に解除したい。
