### PR TITLE
Fix remove observer at corrent timing

### DIFF
--- a/SpringIndicator/SpringIndicator.swift
+++ b/SpringIndicator/SpringIndicator.swift
@@ -396,11 +396,15 @@ public extension SpringIndicator {
             }
         }
         
-        public override func willMoveToSuperview(newSuperview: UIView!) {
+        public override func willMoveToSuperview(newSuperview: UIView?) {
             super.willMoveToSuperview(newSuperview)
             
-            targetView = newSuperview as? UIScrollView
-            addObserver()
+            if let newSuperview = newSuperview {
+                targetView = newSuperview as? UIScrollView
+                addObserver()
+            } else {
+                removeObserver()
+            }
         }
         
         public override func didMoveToSuperview() {


### PR DESCRIPTION
# WHAT

監視しているViewがdealloc（自身がremoveFromSuperview）されても、監視をやめないために
クラッシュしていた問題を解消
